### PR TITLE
Use 10 character short hash for version string of git packages

### DIFF
--- a/Assets/HLSLToolsForVisualStudioConfigGenerator/Editor/HLSLToolsForVisualStudioConfigGenerator.cs
+++ b/Assets/HLSLToolsForVisualStudioConfigGenerator/Editor/HLSLToolsForVisualStudioConfigGenerator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT License
 
 Copyright (c) 2020 hecomi
@@ -52,7 +52,7 @@ public class Window : ScriptableWizard
     }
 
     protected override bool DrawWizardGUI()
-    { 
+    {
         DrawSettings();
         EditorGUILayout.Space();
         UpdateExportInfo();
@@ -114,7 +114,7 @@ public class Window : ScriptableWizard
         get { return Path.Combine(rootDirFullPath, symbolicLinkDirectory); }
     }
 
-    string originalPackageDirectoryFullPath 
+    string originalPackageDirectoryFullPath
     {
         get { return Path.Combine(rootDirFullPath, "Library\\PackageCache"); }
     }
@@ -157,6 +157,10 @@ public class Window : ScriptableWizard
             if (pkg["source"].Equals("builtin")) continue; // skip built-in packages
             if (pkg["source"].Equals("local")) continue; // skip local packages
             var ver = pkg["version"] as string;
+            if (pkg["source"]).Equals("git"){
+                // Git package PackageCache directory appears to use 10 character short hash as the version string
+                ver = (pkg["hash"] as string).Substring(0,10);
+            }
             packages.Add(new PackageInfo { name = name, version = ver });
         }
     }
@@ -164,7 +168,7 @@ public class Window : ScriptableWizard
     string OpenDialogToSelectSymbolicLinkPath()
     {
         return EditorUtility.OpenFolderPanel(
-            "Select directory path to create symbolic links", 
+            "Select directory path to create symbolic links",
             rootDirFullPath,
             string.Empty);
     }
@@ -181,7 +185,7 @@ public class Window : ScriptableWizard
             EditorGUILayout.BeginHorizontal();
             {
                 symbolicLinkDirectory = EditorGUILayout.TextField(
-                    new GUIContent("Symbolic Link Path", "Create symbolic links of all installed packages in this directory."), 
+                    new GUIContent("Symbolic Link Path", "Create symbolic links of all installed packages in this directory."),
                     symbolicLinkDirectory);
                 var layout = GUILayout.Width(25f);
                 if (GUILayout.Button("...", layout))
@@ -246,7 +250,7 @@ public class Window : ScriptableWizard
                     if (GUILayout.Button("Delete", buttonLayout))
                     {
                         bool isDeleteConfirmed = EditorUtility.DisplayDialog(
-                            windowName, 
+                            windowName,
                             "Are you sure you want to delete \"" + symbolicLinkDirectoryFullPath + "\"?",
                             "Delete",
                             "Cancel");
@@ -382,7 +386,7 @@ public class Window : ScriptableWizard
         root.Add("hlsl.additionalIncludeDirectories", dirs);
 
         var jsonStr = MiniJSON.Json.Serialize(root);
-        
+
         using (var stream = new StreamWriter(configJsonFullPath, false, System.Text.Encoding.UTF8))
         {
             stream.Write(jsonStr);


### PR DESCRIPTION
Tested using Unity 2021.2.0f1 as well as 2022.2.1f1. 

For example, when using this package with the following manifest.json:

```json
"dependencies": {
    "com.hecomi.hlsltoolsforvisualstudioconfiggenerator": "https://github.com/hecomi/HLSLToolsForVisualStudioConfigGenerator.git#upm",
...
```

The Library/PackageCache directory has the following directory for the local cache of the repository/package:

`Library\PackageCache\com.hecomi.hlsltoolsforvisualstudioconfiggenerator@24c1c38f35`

The packages-lock.json entry looks like this:

```json
"dependencies": {
    "com.hecomi.hlsltoolsforvisualstudioconfiggenerator": {
      "version": "https://github.com/hecomi/HLSLToolsForVisualStudioConfigGenerator.git#upm",
      "depth": 0,
      "source": "git",
      "dependencies": {},
      "hash": "24c1c38f35bd3111c1b7962ef92870bf5748f875"
    },
...
```

I'm not sure how stable this behavior is in terms of backward compatibility or when the behavior changed (I assume you tested git packages on an older version of unity), but it seems the newer versions of unity use this method of caching.